### PR TITLE
fix OOM for larger files

### DIFF
--- a/bin/deploy-data/ood/submit.yml.erb
+++ b/bin/deploy-data/ood/submit.yml.erb
@@ -10,4 +10,5 @@ batch_connect:
     %s
 
 script:
-  native: ["--mem", "4G"]
+  # Requesting 2Gb for each file
+  native: ["--mem", <%= (Dir.glob("#{audio_path}/*").select { |f| File.file?(f) }.count * 2).to_s + "G" %>]

--- a/bin/deploy-data/ood/template/script.sh
+++ b/bin/deploy-data/ood/template/script.sh
@@ -13,6 +13,5 @@ export SPEECH2TEXT_CPUS_PER_TASK="<SPEECH2TEXT_CPUS_PER_TASK>"
 
 export HF_HUB_OFFLINE="1"
 
-module load cuda
 module load speech2text
 speech2text $audio_path

--- a/env.yml
+++ b/env.yml
@@ -9,6 +9,7 @@ dependencies:
   - libsndfile
   - python=3.10
   - pydub
+  - cuda-libraries-dev
   - pytorch::pytorch
   - pytorch::torchvision
   - pytorch::torchaudio

--- a/env_dev.yml
+++ b/env_dev.yml
@@ -7,3 +7,6 @@ dependencies:
   - pytest
   - black
   - isort
+  - pip
+  - pip:
+    - debugpy

--- a/src/speech2text.py
+++ b/src/speech2text.py
@@ -413,7 +413,7 @@ def main():
     )
     t0 = time.time()
     try:
-        input_file_wav, _ = load_audio(args.INPUT_FILE)
+        input_file_wav, _, _ = load_audio(args.INPUT_FILE)
     except Exception as e:
         logger.error(f".. .. Input file could not be converted: {args.INPUT_FILE}")
         raise (e)

--- a/src/submit.py
+++ b/src/submit.py
@@ -41,6 +41,12 @@ def get_argument_parser():
         help="Temporary folder. If not given, can be set as an environment variable. Optional, defaults to: /scratch/work/$USER/.speech2text/",
     )
     parser.add_argument(
+        "--SPEECH2TEXT_MEM",
+        type=str,
+        default=None,
+        help="Requested memory per job. If not given, should be set as an environment variable.",
+    )
+    parser.add_argument(
         "--SPEECH2TEXT_CPUS_PER_TASK",
         type=int,
         default=os.getenv("SPEECH2TEXT_CPUS_PER_TASK"),
@@ -347,6 +353,9 @@ def submit_dir(args: Namespace, job_name: Path):
         return
 
     est_time, req_ram = estimate_job_requirements(tmp_file_array)
+    # For debugging
+    if args.SPEECH2TEXT_MEM:
+        req_ram = args.SPEECH2TEXT_MEM
     tmp_file_sh = create_sbatch_script_for_array_job(
         tmp_file_array,
         job_name,
@@ -417,6 +426,9 @@ def submit_file(args: Namespace, job_name: Path):
         )
         return
     est_time, req_ram = estimate_job_requirements(args.INPUT)
+    # For debugging
+    if args.SPEECH2TEXT_MEM:
+        req_ram = args.SPEECH2TEXT_MEM
     tmp_file_sh = create_sbatch_script_for_single_file(
         args.INPUT,
         job_name,

--- a/src/submit.py
+++ b/src/submit.py
@@ -308,7 +308,6 @@ def create_sbatch_script_for_array_job(
 #SBATCH --mail-type=FAIL
 export OMP_NUM_THREADS={cpus_per_task}
 export KMP_AFFINITY=granularity=fine,compact
-module load cuda
 python3 {python_source_dir}/speech2text.py {input_file}
 """
     tmp_file_sh = (Path(tmp_dir) / str(job_name)).with_suffix(".sh")
@@ -377,7 +376,6 @@ def create_sbatch_script_for_single_file(
 #SBATCH --mail-user={email}
 #SBATCH --mail-type=END
 #SBATCH --mail-type=FAIL
-module load cuda
 python3 {python_source_dir}/speech2text.py {input_file}
 """
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,6 +2,7 @@ import logging
 import math
 import re
 import subprocess
+import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional, Union
@@ -70,6 +71,8 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
         Containing the audio waveform, in float32 dtype.
     Duration: str
         Audio Duration in HH:MM:SS
+    File_Size: int
+        File size in Gb
     """
     try:
         # Launches a subprocess to decode audio while down-mixing and resampling as necessary.
@@ -100,8 +103,11 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
     duration_pattern = re.compile(r"time=(\d{2}:\d{2}:\d{2})")
     durations = duration_pattern.findall(str(out.stderr))
 
+    #Estimate the file size in Gb
+    file_size = sys.getsizeof(audio) / 1024 / 1024 / 1024 
+
     if durations:
-        return audio, durations[-1]
+        return audio, durations[-1], math.ceil(file_size)
     else:
         raise RuntimeError(f"Failed to get audio duration from {file}")
 


### PR DESCRIPTION
This PR addresses OOM errors in:
1. Job Submission: Now the hard coded "4G" of memory is replaced with 2Gb of memory for each file.
2. Memory request in the Sbatch job is dependent on the largest audio file memory usage

It also addresses #22 to avoid Cuda errors.