### PR TITLE
Fix memory request bug in submit.yml.erb

### DIFF
--- a/bin/deploy-data/ood/submit.yml.erb
+++ b/bin/deploy-data/ood/submit.yml.erb
@@ -10,5 +10,12 @@ batch_connect:
     %s
 
 script:
-  # Requesting 2Gb for each file
-  native: ["--mem", <%= (Dir.glob("#{audio_path}/*").select { |f| File.file?(f) }.count * 2).to_s + "G" %>]
+  # Request 2Gb per file
+  <% if File.directory?(audio_path) %>
+    native: ["--mem", <%= (Dir.glob("#{audio_path}/*").select { |f| File.file?(f) }.count * 2).to_s + "G" %>]
+  <% elsif File.file?(audio_path) %>
+    native: ["--mem", "2G"]
+  <% else %>
+    raise "Invalid audio_path: #{audio_path} is neither a file nor a directory."
+  <% end %>
+  


### PR DESCRIPTION
Fixes a bug in `submit.yml.erb`.

Before fix: If an audio file is submitted instead of a folder, the script requests 0G RAM causing the submission to crash. 

After fix: If an audio file is submitted instead of a folder, the script requests 2G RAM. In case of a folder, 2G x number of files of RAM is requested.