### PR TITLE
Fix file name with space

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ To clean up:
 - purge loaded modules with `module purge`
 - remove the local development repo folders `0000-0`, `0000-1`, etc. 
 - remove the OOD sandbox app folder `/scratch/work/$USERNAME/.ondemand/dev/speech2text-dev`
+- remove the version-specific module file (`0000-0.lua`, `0000-1.lua`, etc.) at `/appl/manual_installations/modules/speech2text/`
 
 
 ## Build and run with Singularity

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To deploy both command line interface (CLI) module and the Open On Demand (OOD) 
 bin/deploy cli ood
 ```
 
-or only the other if only one needs updating.
+or only the other if only one needs updating. To test the OOD app, you can install using `ood-dev` to install the OOD sandbox app.
 
 Check the contents of the script for details.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Supported languages are:
 arabic (ar), armenian (hy), bulgarian (bg), catalan (ca), chinese (zh), czech (cs), danish (da), dutch (nl), english (en), estonian (et), finnish (fi), french (fr), galician (gl), german (de), greek (el), hebrew (he), hindi (hi), hungarian (hu), icelandic (is), indonesian (id), italian (it), japanese (ja), kazakh (kk), korean (ko), latvian (lv), lithuanian (lt), malay (ms), marathi (mr), nepali (ne), norwegian (no), persian (fa), polish (pl), portuguese (pt), romanian (ro), russian (ru), serbian (sr), slovak (sk), slovenian (sl), spanish (es), swedish (sv), thai (th), turkish (tr), ukrainian (uk), urdu (ur), vietnamese (vi)
 
 
-## Deploy on Aalto Triton
+## Deploy on Aalto Triton (production)
 
 Create a base folder for the app if haven't been created
 
@@ -54,7 +54,7 @@ To deploy both command line interface (CLI) module and the Open On Demand (OOD) 
 bin/deploy cli ood
 ```
 
-or only the other if only one needs updating. To test the OOD app, you can install using `ood-dev` to install the OOD sandbox app.
+or only the other if only one needs updating.
 
 Check the contents of the script for details.
 
@@ -205,9 +205,11 @@ test-data/fi/test1.mp3
 ```
 
 
-## Tests and linting
+## Development
 
-Create development environment
+### Local development
+
+Create a development conda environment
 ```bash
 mamba create --file env_dev.yml --prefix env-dev/
 mamba activate env-dev/
@@ -223,9 +225,63 @@ Lint code in `src/`
 black src && isort src
 ```
 
+### Deploy on Aalto Triton (development and testing) 
+
+Create a base folder for the app if haven't been created
+
+```
+mkdir /appl/manual_installations/software/speech2text
+```
+
+Clone git repo and change directory
+
+```bash
+cd /appl/manual_installations/software/speech2text
+git clone https://github.com/AaltoRSE/speech2text.git 0000-0
+cd 0000-0
+```
+
+For development and testing, use folder names `0000-0`, `0000-1`, etc. to distinguish them from the production folders.
+
+Create a conda environment to `env/`
+
+```bash
+module load mamba
+mamba env create --file env.yml --prefix env/
+```
+
+Deploy the command line interface (CLI) module and the Open On Demand (OOD) sandbox app with
+
+```bash
+bin/deploy cli ood-dev
+```
+
+or only the other if only one needs updating.
+
+To test the command line app, load the command line module with
+
+```
+module load speech2text/0000-0
+```
+
+and check its [Usage](#usage).
+
+To test the OOD app, start the speech2text sandbox app from OOD.
+
+To clean up:
+
+- purge loaded modules with `module purge`
+- remove the local development repo folders `0000-0`, `0000-1`, etc. 
+- remove the OOD sandbox app folder `/scratch/work/$USERNAME/.ondemand/dev/speech2text-dev`
+
+
 ## Build and run with Singularity
 
->**__IMPORTANT:__** This is out of date!
+>**__IMPORTANT:__**
+>
+> This is out of date! 
+>
+> The software is currently installed to a conda environment. The Singularity definition file is included here as a future reference if needed.
 
 Although currently not needed, the repo also contains a Singularity definition file `speech2text.def` in project root. 
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -107,6 +107,9 @@ if [ "$OOD" = true ]
 then
 
   echo "Deploy the Open OnDemand (OOD) app"
+  
+  #Update supported languages
+  python3 deploy-data/update_ood_form_values.py
 
   SCRIPT="$SCRIPT_DIR"/deploy-data/ood/template/script.sh
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -14,9 +14,11 @@ Usage:
 
     $ deploy ood
     
-    Deploy both the CLI and OOD app:
+    Deploy the Open Ondemand (OOD) sandbox app:
 
-    $ deploy cli ood
+    $ deploy ood-dev
+
+    These options could be used together.
 
 EOF
 }
@@ -47,6 +49,7 @@ SPEECH2TEXT_CPUS_PER_TASK="6"
 
 CLI=false
 OOD=false
+OODDEV=false
 
 if [ "$#" -gt 0 ]; then
   for arg in "$@"; do
@@ -55,6 +58,9 @@ if [ "$#" -gt 0 ]; then
     fi
     if [[ "$arg" == "ood" ]]; then
       OOD=true
+    fi
+    if [[ "$arg" == "ood-dev" ]]; then
+      OODDEV=true
     fi
   done
 else
@@ -145,5 +151,37 @@ then
   rm -rf "$TEMP_DIR"
 
   echo ".. OOD files pushed to: $REPO_URL. (Do not forget to run the ansible scripts!)"
+
+fi
+
+
+# --------------------------------------------------
+# Deploy as an Open OnDemand app sandbox app
+
+if [ "$OODDEV" = true ]
+then
+
+  echo "Deploy the Open OnDemand (OOD) sandbox"
+
+  SCRIPT="$SCRIPT_DIR"/deploy-data/ood/template/script.sh
+
+  sed -i "s|<VERSION>|$VERSION|g" $SCRIPT
+  sed -i "s|<SPEECH2TEXT>|$SPEECH2TEXT|g" $SCRIPT
+  sed -i "s|<CONDA_ENV>|$CONDA_ENV|g" $SCRIPT
+  sed -i "s|<HF_HOME>|$HF_HOME|g" $SCRIPT
+  sed -i "s|<PYANNOTE_CACHE>|$PYANNOTE_CACHE|g" $SCRIPT
+  sed -i "s|<TORCH_HOME>|$TORCH_HOME|g" $SCRIPT
+  sed -i "s|<PYANNOTE_CONFIG>|$PYANNOTE_CONFIG|g" $SCRIPT
+  sed -i "s|<NUMBA_CACHE_DIR>|$NUMBA_CACHE_DIR|g" $SCRIPT
+  sed -i "s|<MPLCONFIGDIR>|$MPLCONFIGDIR|g" $SCRIPT
+  sed -i "s|<SPEECH2TEXT_MEM>|$SPEECH2TEXT_MEM|g" $SCRIPT
+  sed -i "s|<SPEECH2TEXT_CPUS_PER_TASK>|$SPEECH2TEXT_CPUS_PER_TASK|g" $SCRIPT
+
+  
+  USERNAME=$(whoami)
+  mkdir -p /scratch/work/$USERNAME/.ondemand/dev/speech2text-dev
+  cp -r bin/deploy-data/ood/* /scratch/work/$USERNAME/.ondemand/dev/speech2text-dev
+
+  echo ".. OOD sandbox app is installed!"
 
 fi

--- a/bin/deploy
+++ b/bin/deploy
@@ -108,7 +108,7 @@ then
 
   echo "Deploy the Open OnDemand (OOD) app"
   
-  #Update supported languages
+  # Update supported languages and models
   python3 deploy-data/update_ood_form_values.py
 
   SCRIPT="$SCRIPT_DIR"/deploy-data/ood/template/script.sh
@@ -166,6 +166,9 @@ then
 
   echo "Deploy the Open OnDemand (OOD) sandbox app"
 
+  # Update supported languages and models
+  python3 deploy-data/update_ood_form_values.py
+
   SCRIPT="$SCRIPT_DIR"/deploy-data/ood/template/script.sh
 
   sed -i "s|<VERSION>|$VERSION|g" $SCRIPT
@@ -179,7 +182,6 @@ then
   sed -i "s|<MPLCONFIGDIR>|$MPLCONFIGDIR|g" $SCRIPT
   sed -i "s|<SPEECH2TEXT_MEM>|$SPEECH2TEXT_MEM|g" $SCRIPT
   sed -i "s|<SPEECH2TEXT_CPUS_PER_TASK>|$SPEECH2TEXT_CPUS_PER_TASK|g" $SCRIPT
-
   
   USERNAME=$(whoami)
   mkdir -p /scratch/work/$USERNAME/.ondemand/dev/speech2text-dev

--- a/bin/deploy
+++ b/bin/deploy
@@ -15,10 +15,10 @@ Usage:
     $ deploy ood
     
     Deploy the Open Ondemand (OOD) sandbox app:
-
+/
     $ deploy ood-dev
 
-    These options could be used together.
+    These options can be used together.
 
 EOF
 }
@@ -27,8 +27,8 @@ EOF
 # https://stackoverflow.com/questions/39340169/dir-cd-dirname-bash-source0-pwd-how-does-that-work
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-# Version variables is the second to last path component
-# e.g. /path/to/speech2text/20240314/bin/ -> version = 20240314
+# Version variable is the second to last path component
+# e.g. /path/to/speech2text/123456/bin/ -> version = 123456
 VERSION=$(basename "$(dirname "$SCRIPT_DIR")")
 
 # Other variables
@@ -64,7 +64,7 @@ if [ "$#" -gt 0 ]; then
     fi
   done
 else
-  echo "Provide at least one argument: cli or ood"
+  echo "Provide at least one argument: cli, ood, ood-dev"
   exit 1
 fi
 
@@ -156,12 +156,12 @@ fi
 
 
 # --------------------------------------------------
-# Deploy as an Open OnDemand app sandbox app
+# Deploy as an Open OnDemand sandbox app
 
 if [ "$OODDEV" = true ]
 then
 
-  echo "Deploy the Open OnDemand (OOD) sandbox"
+  echo "Deploy the Open OnDemand (OOD) sandbox app"
 
   SCRIPT="$SCRIPT_DIR"/deploy-data/ood/template/script.sh
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -109,7 +109,7 @@ then
   echo "Deploy the Open OnDemand (OOD) app"
   
   # Update supported languages and models
-  python3 deploy-data/update_ood_form_values.py
+  python3 bin/deploy-data/update_ood_form_values.py
 
   SCRIPT="$SCRIPT_DIR"/deploy-data/ood/template/script.sh
 
@@ -167,7 +167,7 @@ then
   echo "Deploy the Open OnDemand (OOD) sandbox app"
 
   # Update supported languages and models
-  python3 deploy-data/update_ood_form_values.py
+  python3 bin/deploy-data/update_ood_form_values.py
 
   SCRIPT="$SCRIPT_DIR"/deploy-data/ood/template/script.sh
 

--- a/bin/deploy-data/ood/form.js
+++ b/bin/deploy-data/ood/form.js
@@ -1,0 +1,27 @@
+/**
+ *  Decode the audio_path to replace '%20' with space
+ */
+function decode_audio_path() {
+    let audio_path = $("#batch_connect_session_context_audio_path");
+
+    audio_path.val(decodeURIComponent(audio_path.val()))
+}
+
+/**
+ * Sets the event handler for file selector button.
+ * Triggering the handler based on the field change doesn't work
+ * as the field doesn't get the focus.
+ */
+function set_audio_path_handler() {
+    let audio_path_button = $(
+        "#batch_connect_session_context_audio_path_path_selector_button"
+    );
+    audio_path_button.click(decode_audio_path);
+}
+
+/**
+ *  Install event handlers
+ */
+$(document).ready(function () {
+    set_audio_path_handler();
+});

--- a/bin/deploy-data/ood/form.yml
+++ b/bin/deploy-data/ood/form.yml
@@ -26,7 +26,7 @@ attributes:
     display: true
     help: |
       Select the language for the audio file(s).
-    options: #Will be filled with bin/deploy-data/update_supported_lang.py
+    options: # Will be filled with bin/deploy-data/update_ood_form_values.py
     
   
   email_field:
@@ -45,4 +45,4 @@ attributes:
     display: true
     help: |
       (Optional) Select the whisper model.
-    options: #Will be filled with bin/deploy-data/update_supported_lang.py
+    options: # Will be filled with bin/deploy-data/update_ood_form_values.py

--- a/bin/deploy-data/ood/form.yml
+++ b/bin/deploy-data/ood/form.yml
@@ -26,52 +26,8 @@ attributes:
     display: true
     help: |
       Select the language for the audio file(s).
-    options:
-    - arabic
-    - armenian
-    - bulgarian
-    - catalan
-    - chinese
-    - czech
-    - danish
-    - dutch
-    - english
-    - estonian
-    - finnish
-    - french
-    - galician
-    - german
-    - greek
-    - hebrew
-    - hindi
-    - hungarian
-    - icelandic
-    - indonesian
-    - italian
-    - japanese
-    - kazakh
-    - korean
-    - latvian
-    - lithuanian
-    - malay
-    - marathi
-    - nepali
-    - norwegian
-    - persian
-    - polish
-    - portuguese
-    - romanian
-    - russian
-    - serbian
-    - slovak
-    - slovenian
-    - spanish
-    - swedish
-    - thai
-    - turkish
-    - ukrainian
-    - urdu
-    - vietnamese
+    options: #Will be filled with bin/deploy-data/update_supported_lang.py
+    
   
   email_field:
     label: Email
@@ -89,7 +45,4 @@ attributes:
     display: true
     help: |
       (Optional) Select the whisper model.
-    options:
-    - [ "default",  "large-v3" ]
-    - [ "v2",  "large-v2" ]
-    - [ "v3",  "large-v3" ]
+    options: #Will be filled with bin/deploy-data/update_supported_lang.py

--- a/bin/deploy-data/ood/manifest.yml
+++ b/bin/deploy-data/ood/manifest.yml
@@ -4,6 +4,7 @@ category: Interactive Apps
 subcategory: Speech2text
 role: batch_connect
 description: |
-    This is a form to submit a speech2text job request.
+    This is a form to submit a speech2text job request.      
+    [Link to the documentation.](https://scicomp.aalto.fi/triton/apps/speech2text/)
 # metadata:
 #   field_of_science: botany

--- a/bin/deploy-data/ood/submit.yml.erb
+++ b/bin/deploy-data/ood/submit.yml.erb
@@ -7,7 +7,7 @@ batch_connect:
     export SPEECH2TEXT_EMAIL=<%= email_field %>
     export audio_path="<%= audio_path %>"
     export SPEECH2TEXT_WHISPER_MODEL=<%= model_selector %>
-    export SPEECH2TEXT_ONDEMAND=true
+    export SPEECH2TEXT_ONDEMAND=True
     %s
 
 script:

--- a/bin/deploy-data/ood/submit.yml.erb
+++ b/bin/deploy-data/ood/submit.yml.erb
@@ -5,7 +5,7 @@ batch_connect:
   script_wrapper: |
     export SPEECH2TEXT_LANGUAGE=<%= language_field %>
     export SPEECH2TEXT_EMAIL=<%= email_field %>
-    export audio_path=<%= audio_path %>
+    export audio_path="<%= audio_path %>"
     export SPEECH2TEXT_WHISPER_MODEL=<%= model_selector %>
     %s
 

--- a/bin/deploy-data/ood/submit.yml.erb
+++ b/bin/deploy-data/ood/submit.yml.erb
@@ -7,6 +7,7 @@ batch_connect:
     export SPEECH2TEXT_EMAIL=<%= email_field %>
     export audio_path="<%= audio_path %>"
     export SPEECH2TEXT_WHISPER_MODEL=<%= model_selector %>
+    export SPEECH2TEXT_ONDEMAND=true
     %s
 
 script:

--- a/bin/deploy-data/ood/template/script.sh
+++ b/bin/deploy-data/ood/template/script.sh
@@ -14,4 +14,4 @@ export SPEECH2TEXT_CPUS_PER_TASK="<SPEECH2TEXT_CPUS_PER_TASK>"
 export HF_HUB_OFFLINE="1"
 
 module load speech2text
-speech2text $audio_path
+speech2text "$audio_path"

--- a/bin/deploy-data/ood/template/script.sh
+++ b/bin/deploy-data/ood/template/script.sh
@@ -13,5 +13,5 @@ export SPEECH2TEXT_CPUS_PER_TASK="<SPEECH2TEXT_CPUS_PER_TASK>"
 
 export HF_HUB_OFFLINE="1"
 
-module load speech2text
+module load speech2text/<VERSION>
 speech2text "$audio_path"

--- a/bin/deploy-data/update_ood_form_values.py
+++ b/bin/deploy-data/update_ood_form_values.py
@@ -1,0 +1,29 @@
+import yaml
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+from src.settings import (supported_languages, 
+                          available_whisper_models, 
+                          default_whisper_model)
+
+# Path to the form.yml file
+form_yml_path = 'bin/deploy-data/ood/form1.yml'
+
+# Load the existing form.yml
+with open(form_yml_path, 'r') as file:
+    form_data = yaml.safe_load(file)
+
+# Update the language_field options with supported languages
+form_data['attributes']['language_field']['options'] = list(supported_languages.keys())
+
+# Update the model_selector options with available whisper models
+form_data['attributes']['model_selector']['options'] = [
+    ["default", default_whisper_model]
+] + [[model, model] for model in available_whisper_models]
+
+# Write the updated data back to form.yml
+with open(form_yml_path, 'w') as file:
+    yaml.dump(form_data, file, default_flow_style=False, sort_keys=False)
+
+print("form.yml has been updated with supported languages from settings.py.")

--- a/bin/deploy-data/update_ood_form_values.py
+++ b/bin/deploy-data/update_ood_form_values.py
@@ -26,4 +26,4 @@ form_data['attributes']['model_selector']['options'] = [
 with open(form_yml_path, 'w') as file:
     yaml.dump(form_data, file, default_flow_style=False, sort_keys=False)
 
-print("form.yml has been updated with supported languages and Whisper models from settings.py.")
+print(".. form.yml has been updated with supported languages and Whisper models from settings.py.")

--- a/bin/deploy-data/update_ood_form_values.py
+++ b/bin/deploy-data/update_ood_form_values.py
@@ -8,7 +8,7 @@ from src.settings import (supported_languages,
                           default_whisper_model)
 
 # Path to the form.yml file
-form_yml_path = 'bin/deploy-data/ood/form1.yml'
+form_yml_path = 'bin/deploy-data/ood/form.yml'
 
 # Load the existing form.yml
 with open(form_yml_path, 'r') as file:

--- a/bin/deploy-data/update_ood_form_values.py
+++ b/bin/deploy-data/update_ood_form_values.py
@@ -26,4 +26,4 @@ form_data['attributes']['model_selector']['options'] = [
 with open(form_yml_path, 'w') as file:
     yaml.dump(form_data, file, default_flow_style=False, sort_keys=False)
 
-print("form.yml has been updated with supported languages from settings.py.")
+print("form.yml has been updated with supported languages and Whisper models from settings.py.")

--- a/docs/source/user_guide.md
+++ b/docs/source/user_guide.md
@@ -1,6 +1,6 @@
 # User Guide
 
-The Aalto speech2text user guide can now be found under the Aalto Triton documentation: 
+The Aalto speech2text user guide is available at the Aalto Triton documentation: 
 
 [https://scicomp.aalto.fi/triton/apps/speech2text/](https://scicomp.aalto.fi/triton/apps/speech2text/)
 

--- a/env.yml
+++ b/env.yml
@@ -9,12 +9,16 @@ dependencies:
   - libsndfile
   - python=3.10
   - pydub
+  - pytorch-lightning=2.2.5
   - nvidia::cuda-libraries-dev
-  - pytorch::pytorch
+  - pytorch::pytorch=2.3.1=py3.10_cuda12.1_cudnn8.9.2_0
   - pytorch::torchvision
   - pytorch::torchaudio
-  - pytorch::pytorch-cuda
+  - pytorch::pytorch-cuda=12.1
   - pip
   - pip:
     - pyannote.audio
-    - whisperx @ git+https://github.com/m-bain/whisperx.git
+    # Requires ctranslate 4.4.0 and faster-whisper 1.0.3. Link to the issue: https://github.com/m-bain/whisperX/issues/901
+    # "https://github.com/m-bain/whisperX/commit/caa7121064c1bb406be30c50891a9b8217252592" or
+    # "https://github.com/m-bain/whisperX/commit/5080b7188c3666b5d8648346c0c12599a58bd695"
+    - whisperx @ git+https://github.com/federicotorrielli/BetterWhisperX

--- a/env.yml
+++ b/env.yml
@@ -7,6 +7,7 @@ dependencies:
   - git
   - ffmpeg
   - libsndfile
+  - numpy=1.26.4
   - python=3.10
   - pydub
   - pytorch-lightning=2.2.5

--- a/src/speech2text.py
+++ b/src/speech2text.py
@@ -54,12 +54,6 @@ def get_argument_parser():
         help="Input audio file OR a text file with a single input audio file on every line. Mandatory.",
     )
     parser.add_argument(
-        "--SPEECH2TEXT_TMP",
-        type=str,
-        default=os.getenv("SPEECH2TEXT_TMP"),
-        help="Temporary folder. If not given, should be set as an environment variable.",
-    )
-    parser.add_argument(
         "--AUTH_TOKEN",
         type=str,
         default=os.getenv("AUTH_TOKEN"),

--- a/src/speech2text.py
+++ b/src/speech2text.py
@@ -375,7 +375,14 @@ def diarize(file: str, config: str, token: str, result_list: dict):
 
 def main():
     parser = get_argument_parser()
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+
+    # Join all parts of the INPUT argument to handle spaces
+    if unknown:
+        args.INPUT_FILE = ' '.join([args.INPUT_FILE] + unknown)
+    else:
+        args.INPUT_FILE = args.INPUT_FILE
+        
     logger.info(f"Parsed arguments: {args}")
 
     logger.info(f"Start processing input file: {args.INPUT_FILE}")

--- a/src/submit.py
+++ b/src/submit.py
@@ -118,7 +118,7 @@ def parse_job_name(input_path: str) -> str:
     str
         The job name extracted from the input path.
     """
-    return Path(input_path).name.replace(" ", "_")
+    return "speech2text_" + Path(input_path).name.replace(" ", "_")
 
 
 def parse_output_dir(input_path: str, create_if_not_exists: bool = True) -> str:

--- a/src/submit.py
+++ b/src/submit.py
@@ -567,7 +567,8 @@ where 'mylanguage' is one of the supported languages:
         submit_dir(args, job_name)
     else:
         print(
-            ".. Submission failed: First argument needs to be an existing audio file or a directory with audio files.\n"
+            f".. Submission failed: First argument needs to be an existing audio file or a directory with audio files.\n \
+            The input was set to {args.INPUT}"
         )
 
 

--- a/src/submit.py
+++ b/src/submit.py
@@ -115,7 +115,7 @@ def parse_job_name(input_path: str) -> str:
 
     Returns
     -------
-    Path
+    str
         The job name extracted from the input path.
     """
     return Path(input_path).name.replace(" ", "_")

--- a/src/submit.py
+++ b/src/submit.py
@@ -568,7 +568,7 @@ where 'mylanguage' is one of the supported languages:
     else:
         print(
             f".. Submission failed: First argument needs to be an existing audio file or a directory with audio files.\n \
-            The input was set to {args.INPUT}"
+            The input was set to '{args.INPUT}'"
         )
 
 

--- a/src/submit.py
+++ b/src/submit.py
@@ -367,7 +367,7 @@ def submit_dir(args: Namespace, job_name: Path):
     )
 
     # Log
-    print(f"Results will be written to folder: {output_dir}\n")
+    print(f"Results will be written to folder: '{output_dir}'\n")
 
     # Submit
     cmd = f"sbatch {tmp_file_sh.absolute()}"
@@ -440,7 +440,7 @@ def submit_file(args: Namespace, job_name: Path):
     )
 
     # Log
-    print(f"Results will be written to folder: {output_dir}\n")
+    print(f"Results will be written to folder: '{output_dir}'\n")
 
     # Submit
     cmd = f"sbatch {tmp_file_sh.absolute()}"
@@ -515,7 +515,7 @@ def main():
     
     print(f"\nSubmit speech2text jobs with arguments:")
     for key, value in vars(args).items():
-        print(f"\t{key}: {value}")
+        print(f"\t{key}: '{value}'")
     print()
 
     # Check temporary folder
@@ -553,17 +553,17 @@ where 'mylanguage' is one of the supported languages:
 
     # Notify about temporary folder location
     print(
-        f"Log files (.out) and batch submit scripts (.sh) will be written to: {args.SPEECH2TEXT_TMP}\n"
+        f"Log files (.out) and batch submit scripts (.sh) will be written to: '{args.SPEECH2TEXT_TMP}'\n"
     )
 
     # Submit file or directory
     args.INPUT = Path(args.INPUT).absolute()
     job_name = parse_job_name(args.INPUT)
     if Path(args.INPUT).is_file():
-        print(f"Input file: {args.INPUT}\n")
+        print(f"Input file: '{args.INPUT}'\n")
         submit_file(args, job_name)
     elif Path(args.INPUT).is_dir():
-        print(f"Input directory: {args.INPUT}\n")
+        print(f"Input directory: '{args.INPUT}'\n")
         submit_dir(args, job_name)
     else:
         print(

--- a/src/submit.py
+++ b/src/submit.py
@@ -206,7 +206,7 @@ def create_array_input_file(
     return tmp_file_array
 
 
-def estimate_job_requirements(input_path: PosixPath) -> (str, int):
+def estimate_job_requirements(input_path: PosixPath) -> tuple[str, int]:
     """
     Estimate total run time based on input file/folder.
 

--- a/src/submit.py
+++ b/src/submit.py
@@ -104,9 +104,9 @@ def get_existing_result_files(input_file: str, output_dir: str) -> "tuple[list, 
     return existing_result_files, missing_result_files
 
 
-def parse_job_name(input_path: str) -> Path:
+def parse_job_name(input_path: str) -> str:
     """
-    Convert input file/folder to path object.
+    Convert input file/folder to str and replace spaces with underscore.
 
     Parameters
     ----------
@@ -118,7 +118,7 @@ def parse_job_name(input_path: str) -> Path:
     Path
         The job name extracted from the input path.
     """
-    return Path(input_path).name
+    return Path(input_path).name.replace(" ", "_")
 
 
 def parse_output_dir(input_path: str, create_if_not_exists: bool = True) -> str:
@@ -505,7 +505,14 @@ def check_whisper_model(name: str) -> bool:
 def main():
     # Parse arguments
     parser = get_argument_parser()
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+
+    # Join all parts of the INPUT argument to handle spaces
+    if unknown:
+        args.INPUT = ' '.join([args.INPUT] + unknown)
+    else:
+        args.INPUT = args.INPUT
+    
     print(f"\nSubmit speech2text jobs with arguments:")
     for key, value in vars(args).items():
         print(f"\t{key}: {value}")

--- a/src/submit.py
+++ b/src/submit.py
@@ -17,7 +17,7 @@ from pathlib import Path, PosixPath
 
 import settings
 from utils import (add_durations, convert_language_to_abbreviated_form,
-                   load_audio)
+                   load_audio, get_tmp_folder)
 
 # This is the speedup to realtime for transcribing the audio file.
 # The real number is higher than 15 (close to 25), this is just to make sure the job has enough time to complete.
@@ -37,7 +37,7 @@ def get_argument_parser():
     parser.add_argument(
         "--SPEECH2TEXT_TMP",
         type=str,
-        default=os.getenv("SPEECH2TEXT_TMP"),
+        default=get_tmp_folder(),
         help="Temporary folder. If not given, can be set as an environment variable. Optional, defaults to: /scratch/work/$USER/.speech2text/",
     )
     parser.add_argument(

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import os
 import re
 import subprocess
 import sys
@@ -51,6 +52,11 @@ def seconds_to_human_readable_format(seconds: int) -> str:
         hours += 1
 
     return f"{hours:02}:{minutes:02}:{seconds:02}"
+
+
+def get_tmp_folder():
+    current_folder = os.getcwd()
+    return current_folder if 'ondemand' in current_folder else os.getenv("SPEECH2TEXT_TMP")
 
 
 def load_audio(file: str, sr: int = SAMPLE_RATE):

--- a/src/utils.py
+++ b/src/utils.py
@@ -56,7 +56,7 @@ def seconds_to_human_readable_format(seconds: int) -> str:
 
 def get_tmp_folder():
     ood_folder = os.getcwd()
-    return ood_folder if os.getenv('SPEECH2TEXT_ONDEMAND') is True else os.getenv("SPEECH2TEXT_TMP")
+    return ood_folder if os.getenv('SPEECH2TEXT_ONDEMAND') else os.getenv("SPEECH2TEXT_TMP")
 
 
 def load_audio(file: str, sr: int = SAMPLE_RATE):

--- a/src/utils.py
+++ b/src/utils.py
@@ -55,8 +55,8 @@ def seconds_to_human_readable_format(seconds: int) -> str:
 
 
 def get_tmp_folder():
-    current_folder = os.getcwd()
-    return current_folder if 'ondemand' in current_folder else os.getenv("SPEECH2TEXT_TMP")
+    ood_folder = os.getcwd()
+    return ood_folder if os.getenv('SPEECH2TEXT_ONDEMAND') is True else os.getenv("SPEECH2TEXT_TMP")
 
 
 def load_audio(file: str, sr: int = SAMPLE_RATE):


### PR DESCRIPTION
In this PR, these issues are addressed:

- #31. This is done by adding a dynamic form for OOD, and better argument parser for the python script.
- #30. This is mainly for OOD users to have all the log in the OOD app.
- #29. If the file is not supported, the name of the file will be logged for better debugging.
- #26. Now deploying script supports `ood-dev` to easily install the ood sandbox for testing.

In addition, the `env.yml` has specific versions for `faster-whisper`, `ctranslate`, `whisperX`, `cuda`, and `pytorch` for easier environment building.

Last but not least, this PR adds a prefix to slurm `job_name` for easier statistics analysis using slurm database.